### PR TITLE
Add versions of the helper methods that allow a user to specify React and ReactDOM

### DIFF
--- a/TEST_HELPERS.md
+++ b/TEST_HELPERS.md
@@ -2,7 +2,7 @@
 
 Somewhere along the line, while you were creating all those awesome simulations in Wix Component Studio, you may have wondered to yourself: is there any way I can use these in tests? The answer is yes.
 
-`wcs-core` exports three methods to help test components with simulations: `simulationToJsx`, `setupSimulationStage`, and `renderSimulation.
+`wcs-core` exports three methods to help test components with simulations: `simulationToJsx`, `setupSimulationStage`, and `renderSimulation`.
 
 `simulationToJsx` takes a simulation and returns a JSX Element representing the component with the simulation props and wrapped in a wrapper (if relevant).
 
@@ -23,6 +23,20 @@ renderSimulation(simulation: ISimulation) => { canvas: HTMLElement, cleanup: () 
 ```
 
 Where ISimulation is defined [here](https://github.com/wixplosives/wcs-core/blob/d91a792a52b916fb6dc55b7a4f7c49715a010168/src/types.ts#L40).
+
+Additionally, for cases in which it is necessary or desired to provide a specific version of React (rather than using the version imported by `wcs-core`), both the `simulationToJsx` and `renderSimulation` methods have another version, `simulationToJsxWithExplicitReact` and `renderSimulationWithExplicitReact`, which expect versions of React and ReactDOM to be provided.
+
+```ts
+simulationToJsxWithExplicitReact(React: typeof import('react'), simulation: ISimulation) => JSX.Element;
+```
+
+```ts
+renderSimulationWithExplicitReact(React: typeof import('react'), ReactDOM: typeof import('react-dom'), simulation: ISimulation) => { canvas: HTMLElement, cleanup: () => void };
+```
+
+**Do not mix usage of these "explicitReact" methods and the basic "implicit React" methods in the same project. This could result in multiple versions of React and ReactDOM being loaded at the same time.**
+
+### An Example Test
 
 Let's take a look at an example of a test running in [MochaPup](https://github.com/wixplosives/mocha-pup) (however, this example should apply to any test that has access to the window during execution).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './create-simulation';
 export * from './types';
 export * from './test-helpers';
+export * from './test-helpers-with-explicit-react';

--- a/src/setup-simulation-stage.ts
+++ b/src/setup-simulation-stage.ts
@@ -1,0 +1,100 @@
+import { IWindowEnvironmentProps, ICanvasEnvironmentProps, SetupSimulationStage } from '.';
+import { entries } from './typed-entries';
+
+type CanvasStyles = Pick<
+    CSSStyleDeclaration,
+    | 'backgroundColor'
+    | 'height'
+    | 'width'
+    | 'paddingLeft'
+    | 'paddingRight'
+    | 'paddingBottom'
+    | 'paddingTop'
+    | 'marginLeft'
+    | 'marginRight'
+    | 'marginBottom'
+    | 'marginTop'
+>;
+
+const defaultCanvasStyles: CanvasStyles = {
+    width: 'fit-content',
+    height: 'fit-content',
+    marginLeft: '0px',
+    marginRight: '0px',
+    marginBottom: '0px',
+    marginTop: '0px',
+    paddingLeft: '0px',
+    paddingRight: '0px',
+    paddingBottom: '0px',
+    paddingTop: '0px',
+    backgroundColor: '#fff'
+};
+
+const applyStylesToWindow = (windowStyles: Partial<IWindowEnvironmentProps> = {}) => {
+    const oldWindowHeight = window.outerHeight;
+    const oldWindowWidth = window.outerWidth;
+    const oldBackgroundColor = document.body.style.backgroundColor;
+
+    window.resizeTo(windowStyles.windowWidth || oldWindowWidth, windowStyles.windowHeight || oldWindowHeight);
+    document.body.style.backgroundColor = windowStyles.windowBackgroundColor || oldBackgroundColor;
+
+    return () => {
+        window.resizeTo(oldWindowWidth, oldWindowHeight);
+        document.body.style.backgroundColor = oldBackgroundColor;
+    };
+};
+
+const mapEnvironmentPropsToStyles = (environmentProps: Partial<ICanvasEnvironmentProps>): CanvasStyles => ({
+    width: environmentProps.canvasWidth ? `${environmentProps.canvasWidth}px` : defaultCanvasStyles.width,
+    height: environmentProps.canvasHeight ? `${environmentProps.canvasHeight}px` : defaultCanvasStyles.height,
+    marginLeft: environmentProps.canvasMargin?.left
+        ? `${environmentProps.canvasMargin?.left}px`
+        : defaultCanvasStyles.marginLeft,
+    marginRight: environmentProps.canvasMargin?.right
+        ? `${environmentProps.canvasMargin?.right}px`
+        : defaultCanvasStyles.marginRight,
+    marginBottom: environmentProps.canvasMargin?.bottom
+        ? `${environmentProps.canvasMargin?.bottom}px`
+        : defaultCanvasStyles.marginBottom,
+    marginTop: environmentProps.canvasMargin?.top
+        ? `${environmentProps.canvasMargin?.top}px`
+        : defaultCanvasStyles.marginTop,
+    paddingLeft: environmentProps.canvasPadding?.left
+        ? `${environmentProps.canvasPadding?.left}px`
+        : defaultCanvasStyles.paddingLeft,
+    paddingRight: environmentProps.canvasPadding?.right
+        ? `${environmentProps.canvasPadding?.right}px`
+        : defaultCanvasStyles.paddingRight,
+    paddingBottom: environmentProps.canvasPadding?.bottom
+        ? `${environmentProps.canvasPadding?.bottom}px`
+        : defaultCanvasStyles.paddingBottom,
+    paddingTop: environmentProps.canvasPadding?.top
+        ? `${environmentProps.canvasPadding?.top}px`
+        : defaultCanvasStyles.paddingTop,
+    backgroundColor: environmentProps.canvasBackgroundColor || defaultCanvasStyles.backgroundColor
+});
+
+const applyStylesToCanvas = (canvas: HTMLDivElement, canvasEnvironmentProps: Partial<ICanvasEnvironmentProps> = {}) => {
+    const styles = mapEnvironmentPropsToStyles(canvasEnvironmentProps);
+
+    for (const [styleProperty, stylePropertyValue] of entries(styles)) {
+        canvas.style[styleProperty] = stylePropertyValue;
+    }
+};
+
+export const setupSimulationStage: SetupSimulationStage = simulation => {
+    const canvas = document.createElement('div');
+    canvas.setAttribute('id', 'simulation-canvas');
+
+    const resetWindow = applyStylesToWindow(simulation.environmentProps);
+    applyStylesToCanvas(canvas, simulation.environmentProps);
+
+    document.body.appendChild(canvas);
+
+    const cleanup = () => {
+        canvas.remove();
+        resetWindow();
+    };
+
+    return { canvas: canvas, cleanup };
+};

--- a/src/test-helpers-with-explicit-react.tsx
+++ b/src/test-helpers-with-explicit-react.tsx
@@ -1,5 +1,5 @@
 import { SimulationToJsxWithExplicitReact, RenderSimulationWithExplicitReact } from './types';
-import { setupSimulationStage } from '.';
+import { setupSimulationStage } from './setup-simulation-stage';
 
 /*
  * Do not mix usage of `simulationToJsxWithExplicitReact` and the basic `simulationToJsx` in

--- a/src/test-helpers-with-explicit-react.tsx
+++ b/src/test-helpers-with-explicit-react.tsx
@@ -1,0 +1,33 @@
+import { SimulationToJsxWithExplicitReact, RenderSimulationWithExplicitReact } from './types';
+import { setupSimulationStage } from '.';
+
+/*
+ * Do not mix usage of `simulationToJsxWithExplicitReact` and the basic `simulationToJsx` in
+ * the same project. This could result in multiple versions of React being loaded at the same time.
+ */
+export const simulationToJsxWithExplicitReact: SimulationToJsxWithExplicitReact = (React, sim): JSX.Element => {
+    const { componentType: Comp, props = {}, wrapper: Wrapper } = sim;
+
+    const renderWithPropOverrides = (overrides?: Record<string, any>) => <Comp {...props} {...overrides} />;
+
+    return Wrapper ? <Wrapper renderSimulation={renderWithPropOverrides} /> : <Comp {...props} />;
+};
+
+/*
+ * Do not mix usage of `renderSimulationWithExplicitReact` and the basic `renderSimulation` in
+ * the same project. This could result in multiple versions of React and ReactDOM being loaded at the same time.
+ */
+export const renderSimulationWithExplicitReact: RenderSimulationWithExplicitReact = (React, ReactDOM, simulation) => {
+    const { canvas, cleanup: stageCleanup } = setupSimulationStage(simulation);
+    const Comp = simulationToJsxWithExplicitReact(React, simulation);
+
+    ReactDOM.render(Comp, canvas);
+
+    return {
+        canvas,
+        cleanup: () => {
+            ReactDOM.unmountComponentAtNode(canvas);
+            stageCleanup();
+        }
+    };
+};

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -8,6 +8,10 @@ import {
     ICanvasEnvironmentProps
 } from './types';
 import { entries } from './typed-entries';
+import {
+    renderSimulationWithExplicitReact,
+    simulationToJsxWithExplicitReact
+} from './test-helpers-with-explicit-react';
 
 type CanvasStyles = Pick<
     CSSStyleDeclaration,
@@ -91,11 +95,7 @@ const applyStylesToCanvas = (canvas: HTMLDivElement, canvasEnvironmentProps: Par
 };
 
 export const simulationToJsx: SimulationToJsx = simulation => {
-    const { componentType: Comp, props = {}, wrapper: Wrapper } = simulation;
-
-    const renderWithPropOverrides = (overrides?: Record<string, any>) => <Comp {...props} {...overrides} />;
-
-    return Wrapper ? <Wrapper renderSimulation={renderWithPropOverrides} /> : <Comp {...props} />;
+    return simulationToJsxWithExplicitReact(React, simulation);
 };
 
 export const setupSimulationStage: SetupSimulationStage = simulation => {
@@ -116,16 +116,5 @@ export const setupSimulationStage: SetupSimulationStage = simulation => {
 };
 
 export const renderSimulation: RenderSimulation = simulation => {
-    const { canvas, cleanup: stageCleanup } = setupSimulationStage(simulation);
-    const Comp = simulationToJsx(simulation);
-
-    ReactDOM.render(Comp, canvas);
-
-    return {
-        canvas,
-        cleanup: () => {
-            ReactDOM.unmountComponentAtNode(canvas);
-            stageCleanup();
-        }
-    };
+    return renderSimulationWithExplicitReact(React, ReactDOM, simulation);
 };

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -1,118 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {
-    SetupSimulationStage,
-    RenderSimulation,
-    SimulationToJsx,
-    IWindowEnvironmentProps,
-    ICanvasEnvironmentProps
-} from './types';
-import { entries } from './typed-entries';
+import { RenderSimulation, SimulationToJsx } from './types';
 import {
     renderSimulationWithExplicitReact,
     simulationToJsxWithExplicitReact
 } from './test-helpers-with-explicit-react';
 
-type CanvasStyles = Pick<
-    CSSStyleDeclaration,
-    | 'backgroundColor'
-    | 'height'
-    | 'width'
-    | 'paddingLeft'
-    | 'paddingRight'
-    | 'paddingBottom'
-    | 'paddingTop'
-    | 'marginLeft'
-    | 'marginRight'
-    | 'marginBottom'
-    | 'marginTop'
->;
-
-const defaultCanvasStyles: CanvasStyles = {
-    width: 'fit-content',
-    height: 'fit-content',
-    marginLeft: '0px',
-    marginRight: '0px',
-    marginBottom: '0px',
-    marginTop: '0px',
-    paddingLeft: '0px',
-    paddingRight: '0px',
-    paddingBottom: '0px',
-    paddingTop: '0px',
-    backgroundColor: '#fff'
-};
-
-const applyStylesToWindow = (windowStyles: Partial<IWindowEnvironmentProps> = {}) => {
-    const oldWindowHeight = window.outerHeight;
-    const oldWindowWidth = window.outerWidth;
-    const oldBackgroundColor = document.body.style.backgroundColor;
-
-    window.resizeTo(windowStyles.windowWidth || oldWindowWidth, windowStyles.windowHeight || oldWindowHeight);
-    document.body.style.backgroundColor = windowStyles.windowBackgroundColor || oldBackgroundColor;
-
-    return () => {
-        window.resizeTo(oldWindowWidth, oldWindowHeight);
-        document.body.style.backgroundColor = oldBackgroundColor;
-    };
-};
-
-const mapEnvironmentPropsToStyles = (environmentProps: Partial<ICanvasEnvironmentProps>): CanvasStyles => ({
-    width: environmentProps.canvasWidth ? `${environmentProps.canvasWidth}px` : defaultCanvasStyles.width,
-    height: environmentProps.canvasHeight ? `${environmentProps.canvasHeight}px` : defaultCanvasStyles.height,
-    marginLeft: environmentProps.canvasMargin?.left
-        ? `${environmentProps.canvasMargin?.left}px`
-        : defaultCanvasStyles.marginLeft,
-    marginRight: environmentProps.canvasMargin?.right
-        ? `${environmentProps.canvasMargin?.right}px`
-        : defaultCanvasStyles.marginRight,
-    marginBottom: environmentProps.canvasMargin?.bottom
-        ? `${environmentProps.canvasMargin?.bottom}px`
-        : defaultCanvasStyles.marginBottom,
-    marginTop: environmentProps.canvasMargin?.top
-        ? `${environmentProps.canvasMargin?.top}px`
-        : defaultCanvasStyles.marginTop,
-    paddingLeft: environmentProps.canvasPadding?.left
-        ? `${environmentProps.canvasPadding?.left}px`
-        : defaultCanvasStyles.paddingLeft,
-    paddingRight: environmentProps.canvasPadding?.right
-        ? `${environmentProps.canvasPadding?.right}px`
-        : defaultCanvasStyles.paddingRight,
-    paddingBottom: environmentProps.canvasPadding?.bottom
-        ? `${environmentProps.canvasPadding?.bottom}px`
-        : defaultCanvasStyles.paddingBottom,
-    paddingTop: environmentProps.canvasPadding?.top
-        ? `${environmentProps.canvasPadding?.top}px`
-        : defaultCanvasStyles.paddingTop,
-    backgroundColor: environmentProps.canvasBackgroundColor || defaultCanvasStyles.backgroundColor
-});
-
-const applyStylesToCanvas = (canvas: HTMLDivElement, canvasEnvironmentProps: Partial<ICanvasEnvironmentProps> = {}) => {
-    const styles = mapEnvironmentPropsToStyles(canvasEnvironmentProps);
-
-    for (const [styleProperty, stylePropertyValue] of entries(styles)) {
-        canvas.style[styleProperty] = stylePropertyValue;
-    }
-};
+export { setupSimulationStage } from './setup-simulation-stage';
 
 export const simulationToJsx: SimulationToJsx = simulation => {
     return simulationToJsxWithExplicitReact(React, simulation);
-};
-
-export const setupSimulationStage: SetupSimulationStage = simulation => {
-    const canvas = document.createElement('div');
-    canvas.setAttribute('id', 'simulation-canvas');
-
-    const resetWindow = applyStylesToWindow(simulation.environmentProps);
-    applyStylesToCanvas(canvas, simulation.environmentProps);
-
-    document.body.appendChild(canvas);
-
-    const cleanup = () => {
-        canvas.remove();
-        resetWindow();
-    };
-
-    return { canvas: canvas, cleanup };
 };
 
 export const renderSimulation: RenderSimulation = simulation => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,4 +82,14 @@ export type RenderSimulation = (
     simulation: ISimulation<Record<string, any>>
 ) => { canvas: HTMLElement; cleanup: () => void };
 
+export type RenderSimulationWithExplicitReact = (
+    React: typeof import('react'),
+    ReactDOM: typeof import('react-dom'),
+    simulation: ISimulation<Record<string, any>>
+) => { canvas: HTMLElement; cleanup: () => void };
+
 export type SimulationToJsx = (simulation: ISimulation<Record<string, any>>) => JSX.Element;
+export type SimulationToJsxWithExplicitReact = (
+    React: typeof import('react'),
+    simulation: ISimulation<Record<string, any>>
+) => JSX.Element;


### PR DESCRIPTION
This is useful in contexts where it is important to be able to specify the version of React and ReactDOM which these helper methods use, rather than having them default to the project version.