### PR TITLE
Remove "auto" and null value from environment props canvas size

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,10 +3,10 @@ import React from 'react';
 export type LayoutSize = number;
 
 export interface LayoutSpacing {
-    left: LayoutSize;
-    right: LayoutSize;
-    top: LayoutSize;
-    bottom: LayoutSize;
+    left?: LayoutSize;
+    right?: LayoutSize;
+    top?: LayoutSize;
+    bottom?: LayoutSize;
 }
 
 export type IPreviewEnvironmentPropsBase = IWindowEnvironmentProps & ICanvasEnvironmentProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,6 @@ import React from 'react';
 
 export type LayoutSize = number | null;
 
-export type LayoutSizeWithAuto = LayoutSize | 'auto';
-
 export interface LayoutSpacing {
     left: LayoutSize;
     right: LayoutSize;
@@ -20,8 +18,8 @@ export interface IWindowEnvironmentProps {
 }
 
 export interface ICanvasEnvironmentProps {
-    canvasWidth: LayoutSizeWithAuto;
-    canvasHeight: LayoutSizeWithAuto;
+    canvasWidth: LayoutSize;
+    canvasHeight: LayoutSize;
     canvasBackgroundColor: string;
     canvasMargin: LayoutSpacing;
     canvasPadding: LayoutSpacing;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type LayoutSize = number | null;
+export type LayoutSize = number | undefined;
 
 export interface LayoutSpacing {
     left: LayoutSize;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type LayoutSize = number | undefined;
+export type LayoutSize = number;
 
 export interface LayoutSpacing {
     left: LayoutSize;


### PR DESCRIPTION
Remove `LayoutSizeWithAuto` type