### PR TITLE
feat: generic simulations via @wixc3/simulation-core and @wixc3/react-simulation

### DIFF
--- a/packages/react-simulation/LICENSE
+++ b/packages/react-simulation/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2021 Wix.com
+
+Permission is hereby granted, free of
+charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/react-simulation/README.md
+++ b/packages/react-simulation/README.md
@@ -1,0 +1,39 @@
+# @wixc3/react-simulation
+
+[![npm version](https://img.shields.io/npm/v/@wixc3/react-simulation.svg)](https://www.npmjs.com/package/@wixc3/react-simulation)
+
+Library for creation of React component simulations.
+
+## Usage
+
+Given:
+
+```tsx
+// hello.tsx
+
+import React from 'react';
+
+export interface HelloProps {
+  name: string;
+}
+export const Hello: React.VFC<HelloProps> = ({ name }) => <div>Hello ${name}</div>;
+```
+
+This library can be used to create simulations for `Hello`:
+
+```tsx
+// hello.sim.tsx
+
+import { createSimulation } from '@wixc3/react-simulation';
+import { Hello } from './hello';
+
+createSimulation({
+  name: 'basic simulation',
+  componentType: Hello,
+  props: { name: 'World' },
+});
+```
+
+## License
+
+MIT

--- a/packages/react-simulation/package.json
+++ b/packages/react-simulation/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wixc3/react-simulation",
+  "description": "Library for creation of React component simulations",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "peerDependencies": {
+    "react": "^16.0.0 || ^17.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0"
+  },
+  "dependencies": {
+    "@wixc3/simulation-core": "^1.0.0"
+  },
+  "files": [
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
+  ],
+  "license": "MIT",
+  "repository": "https://github.com/wixplosives/wcs-core/tree/master/packages/react-simulation",
+  "homepage": "https://github.com/wixplosives/wcs-core",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/react-simulation/src/create-simulation.tsx
+++ b/packages/react-simulation/src/create-simulation.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {
+    getPluginsWithHooks,
+    createSimulationBase,
+    OmitSimulation,
+    baseRender,
+    IPROPS,
+    IRenderableHooks,
+    IRenderableMetadataBase,
+    ISimulation,
+} from '@wixc3/simulation-core';
+
+export type OmitReactSimulation<DATA extends IReactSimulation> = Omit<OmitSimulation<DATA>, 'renderer' | 'cleanup'>;
+
+export type CompProps<COMP extends React.ComponentType<any>> = React.ComponentProps<COMP>;
+
+/**
+ * Create simulation of a React component.
+ */
+export function createSimulation<COMP extends React.ComponentType<any>>(
+    input: OmitReactSimulation<IReactSimulation<Partial<CompProps<COMP>>, COMP>>
+): IReactSimulation<CompProps<COMP>, COMP> {
+    const res = createSimulationBase<IReactSimulation<CompProps<COMP>, COMP>>({
+        ...(input as OmitReactSimulation<IReactSimulation<CompProps<COMP>, COMP>>),
+        renderer(target) {
+            baseRender(
+                res,
+                () => {
+                    let element = this.wrapper ? (
+                        <this.wrapper
+                            renderSimulation={(props) => {
+                                const mergedProps: Partial<React.ComponentProps<COMP>> = { ...this.props, ...props };
+                                return <res.componentType {...(mergedProps as CompProps<COMP>)} />;
+                            }}
+                        />
+                    ) : (
+                        <res.componentType {...this.props} />
+                    );
+                    const wrapRenderPlugins = getPluginsWithHooks(res, 'wrapRender');
+                    for (const plugin of wrapRenderPlugins) {
+                        if (plugin.key.plugin?.wrapRender) {
+                            const el = plugin.key.plugin?.wrapRender(plugin.props as never, res, element, target);
+                            element = el || element;
+                        }
+                    }
+                    ReactDOM.render(element, target);
+                },
+                target
+            );
+        },
+        cleanup(target) {
+            ReactDOM.unmountComponentAtNode(target);
+        },
+    });
+    return res;
+}
+
+export interface ISimulationWrapperProps<P> {
+    /**
+     * Call this function to render the simulated component with the simulated props.
+     * @param overrides Allows you to override some of the simulated props with custom values.
+     */
+    renderSimulation: (overrides?: Partial<P>) => React.ReactElement<Partial<P>>;
+}
+
+export interface IReactSimulationHooks<PLUGINPROPS extends IPROPS> extends IRenderableHooks<PLUGINPROPS> {
+    wrapRender?: (
+        props: PLUGINPROPS,
+        renderable: IRenderableMetadataBase,
+        renderableElement: JSX.Element,
+        canvas: HTMLElement
+    ) => null | JSX.Element;
+}
+export interface IReactSimulation<
+    PROPS = any,
+    ComponentType extends React.ComponentType<PROPS> = React.ComponentType<any>
+> extends ISimulation<ComponentType, PROPS, IReactSimulationHooks<never>> {
+    /** The simulated component type. */
+    componentType: ComponentType;
+
+    /** The name of the simulation. */
+    name: string;
+
+    /**
+     * A map between a component property name and its simulated value.
+     */
+    // TODO - change props to be optional field (props?: ...)
+
+    /**
+     * Allows to wrap the simulated component in another component. Useful for providing context,
+     * rendering controlled components, or rendering the simulated component multiple times - for
+     * example a radio button as a radio group.
+     */
+    wrapper?: React.ComponentType<ISimulationWrapperProps<PROPS>>;
+}
+
+/**
+ * @deprecated
+ * use simulation.render instead
+ */
+export const simulationToJsx = (simulation: IReactSimulation): JSX.Element => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { componentType: Comp, props, wrapper: Wrapper } = simulation;
+    const renderWithPropOverrides = (overrides?: Record<string, unknown>) => <Comp {...props} {...overrides} />;
+    return Wrapper ? <Wrapper renderSimulation={renderWithPropOverrides} /> : <Comp {...props} />;
+};

--- a/packages/react-simulation/src/index.ts
+++ b/packages/react-simulation/src/index.ts
@@ -1,0 +1,1 @@
+export * from './create-simulation';

--- a/packages/react-simulation/src/tsconfig.json
+++ b/packages/react-simulation/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  },
+  "references": [{ "path": "../../simulation-core/src" }]
+}

--- a/packages/react-simulation/test/create-simulation.spec.tsx
+++ b/packages/react-simulation/test/create-simulation.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { createSimulation } from '@wixc3/react-simulation';
+import { tagPlugin, cssVarsPlugin, createMetadata } from '@wixc3/simulation-core';
+
+/**
+ * Type tests
+ */
+
+createSimulation({
+    name: 'Test1',
+    props: {},
+    componentType: () => null,
+});
+
+const x: React.FC<{ name: string }> = ({ name, children }) => (
+    <>
+        {name}
+        {children}
+    </>
+);
+
+createSimulation({
+    name: 'Test1',
+    props: { name: 'string', children: [] },
+    componentType: x,
+});
+
+createSimulation({
+    name: 'Test2',
+    props: { name: 'string', children: [] },
+    componentType: x,
+    plugins: [
+        tagPlugin.use({
+            tags: ['a', 'b'],
+        }),
+        cssVarsPlugin.use({
+            '--color': 'red',
+        }),
+    ],
+});
+
+export const a = createMetadata({
+    target: x,
+    plugins: [
+        tagPlugin.use({
+            tags: ['a', 'b'],
+        }),
+    ],
+});

--- a/packages/react-simulation/test/fixtures/checkbox-with-wrapper.sim.ts
+++ b/packages/react-simulation/test/fixtures/checkbox-with-wrapper.sim.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { Checkbox, CheckboxProps } from './checkbox';
+import { createSimulation, ISimulationWrapperProps } from '@wixc3/react-simulation';
+
+const Wrapper = ({ renderSimulation }: ISimulationWrapperProps<CheckboxProps>) => {
+    const [checked, setChecked] = useState(false);
+    return renderSimulation({ checked, onChange: (e) => setChecked(e.target.checked) });
+};
+
+export default createSimulation({
+    name: 'Checkbox with wrapper',
+    componentType: Checkbox,
+    props: {
+        checked: false,
+        id: 'test-checkbox',
+    },
+    wrapper: Wrapper,
+    environmentProps: {
+        canvasWidth: 500,
+        canvasHeight: 600,
+        canvasBackgroundColor: '#0f4972',
+        windowWidth: 1000,
+        windowHeight: 1200,
+    },
+});

--- a/packages/react-simulation/test/fixtures/checkbox.driver.ts
+++ b/packages/react-simulation/test/fixtures/checkbox.driver.ts
@@ -1,0 +1,11 @@
+export class CheckboxDriver {
+    constructor(public root: HTMLInputElement) {}
+
+    isChecked(): boolean {
+        return this.root.checked;
+    }
+
+    toggle(): void {
+        this.root.click();
+    }
+}

--- a/packages/react-simulation/test/fixtures/checkbox.tsx
+++ b/packages/react-simulation/test/fixtures/checkbox.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export interface CheckboxProps {
+    id: string;
+    checked?: boolean;
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+export const Checkbox: React.FC<CheckboxProps> = (props) => {
+    return <input type="checkbox" id={props.id} checked={props.checked} onChange={props.onChange} />;
+};

--- a/packages/react-simulation/test/fixtures/playground.ts
+++ b/packages/react-simulation/test/fixtures/playground.ts
@@ -1,0 +1,25 @@
+import type { IRenderableMetadataBase } from '@wixc3/simulation-core';
+import CheckBoxSim from './checkbox-with-wrapper.sim';
+
+const examples = [CheckBoxSim];
+
+const menu = window.document.createElement('div');
+for (const examp of examples) {
+    const linkButton = window.document.createElement('div');
+    linkButton.style.color = 'blue';
+    linkButton.style.cursor = 'pointer';
+    linkButton.onclick = () => {
+        if (lastCleanUp) {
+            lastCleanUp();
+        }
+        setupAndRun(examp);
+    };
+    menu.appendChild(linkButton);
+}
+window.document.body.appendChild(menu);
+let lastCleanUp: undefined | (() => void);
+const setupAndRun = (data: IRenderableMetadataBase) => {
+    const { canvas, cleanup } = data.setupStage();
+    lastCleanUp = cleanup;
+    data.renderer(canvas);
+};

--- a/packages/react-simulation/test/fixtures/simulation-fixtures.tsx
+++ b/packages/react-simulation/test/fixtures/simulation-fixtures.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { createSimulation } from '@wixc3/react-simulation';
+
+export const mockComponent: React.FC<{ text: string }> = (props) => <div>{props.text}</div>;
+
+export const propsOnlySimulation = createSimulation({
+    componentType: mockComponent,
+    name: 'mock simulation',
+    props: {
+        text: 'this is a test',
+    },
+});
+
+export const overrideProps = {
+    text: 'override text',
+};
+
+export const simulationWithWrapper = createSimulation({
+    componentType: mockComponent,
+    name: 'mock simulation',
+    props: {
+        text: 'this is a test',
+    },
+    wrapper: ({ renderSimulation }) => {
+        return renderSimulation(overrideProps);
+    },
+});
+
+export const simulationWithEnvironmentProps = createSimulation({
+    componentType: mockComponent,
+    name: 'mock simulation',
+    props: {
+        text: 'this is a test',
+    },
+    environmentProps: {
+        canvasWidth: 50,
+        canvasHeight: 100,
+        canvasPadding: { left: 20, right: 10, top: 5, bottom: 2 },
+        canvasMargin: { left: 210, right: 110, top: 51, bottom: 21 },
+        canvasBackgroundColor: 'red',
+        windowWidth: 500,
+        windowHeight: 600,
+        windowBackgroundColor: 'blue',
+    },
+});

--- a/packages/react-simulation/test/render-helpers.spec.ts
+++ b/packages/react-simulation/test/render-helpers.spec.ts
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import { renderSimulation, setupSimulationStage } from '@wixc3/simulation-core';
+import CheckboxWithWrapper from './fixtures/checkbox-with-wrapper.sim';
+import { CheckboxDriver } from './fixtures/checkbox.driver';
+import { simulationWithEnvironmentProps } from './fixtures/simulation-fixtures';
+
+describe('Rendering Simulations', () => {
+    const cleanupAfterTest = new Set<() => unknown>();
+    afterEach(() => {
+        for (const cleanup of cleanupAfterTest) {
+            cleanup();
+        }
+        cleanupAfterTest.clear();
+    });
+
+    describe('setupSimulationStage', () => {
+        it('returns a canvas with the correct environment properties, and then unmounts it', () => {
+            const { canvas, cleanup } = setupSimulationStage(simulationWithEnvironmentProps);
+            cleanupAfterTest.add(cleanup);
+            const { environmentProps } = simulationWithEnvironmentProps;
+            const { canvasMargin, canvasPadding, canvasBackgroundColor, canvasHeight, canvasWidth } =
+                environmentProps || {};
+
+            expect(document.getElementById('simulation-canvas')?.parentElement).to.equal(document.body);
+
+            expect(canvas.style.height).to.equal(`${canvasHeight as number}px`);
+            expect(canvas.style.width).to.equal(`${canvasWidth as number}px`);
+            expect(canvas.style.backgroundColor).to.equal(canvasBackgroundColor);
+            expect(canvas.style.margin).to.equal(
+                `${canvasMargin?.top as number}px ${canvasMargin?.right as number}px ${
+                    canvasMargin?.bottom as number
+                }px ${canvasMargin?.left as number}px`
+            );
+            expect(canvas.style.padding).to.equal(
+                `${canvasPadding?.top as number}px ${canvasPadding?.right as number}px ${
+                    canvasPadding?.bottom as number
+                }px ${canvasPadding?.left as number}px`
+            );
+
+            cleanup();
+            cleanupAfterTest.delete(cleanup);
+
+            expect(document.getElementById('simulation-canvas')).to.equal(null);
+        });
+
+        it('styles the window properly, and then resets it', () => {
+            const originalWindowWidth = window.outerWidth;
+            const originalWindowHeight = window.outerHeight;
+            const originalBodyColor = document.body.style.backgroundColor;
+
+            const { environmentProps } = simulationWithEnvironmentProps;
+
+            const { cleanup } = setupSimulationStage(simulationWithEnvironmentProps);
+            cleanupAfterTest.add(cleanup);
+
+            expect(window.outerWidth).to.equal(environmentProps?.windowWidth);
+            expect(window.outerHeight).to.equal(environmentProps?.windowHeight);
+            expect(document.body.style.backgroundColor).to.equal(environmentProps?.windowBackgroundColor);
+
+            cleanup();
+            cleanupAfterTest.delete(cleanup);
+
+            expect(window.outerWidth).to.equal(originalWindowWidth);
+            expect(window.outerHeight).to.equal(originalWindowHeight);
+            expect(document.body.style.backgroundColor).to.equal(originalBodyColor);
+        });
+    });
+
+    describe('an example test using the render helpers', () => {
+        it('a Checkbox component can be toggled', () => {
+            const { canvas, cleanup } = renderSimulation(CheckboxWithWrapper);
+            cleanupAfterTest.add(cleanup);
+
+            const checkbox = new CheckboxDriver(canvas.children[0] as HTMLInputElement);
+
+            expect(checkbox.isChecked()).equal(false);
+            checkbox.toggle();
+            expect(checkbox.isChecked()).equal(true);
+        });
+    });
+});

--- a/packages/react-simulation/test/tsconfig.json
+++ b/packages/react-simulation/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "types": ["mocha"]
+  },
+  "references": [{ "path": "../src" }, { "path": "../../simulation-core/src" }]
+}

--- a/packages/simulation-core/LICENSE
+++ b/packages/simulation-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2021 Wix.com
+
+Permission is hereby granted, free of
+charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/simulation-core/README.md
+++ b/packages/simulation-core/README.md
@@ -1,0 +1,80 @@
+# @wixc3/simulation-core
+
+[![npm version](https://img.shields.io/npm/v/@wixc3/simulation-core.svg)](https://www.npmjs.com/package/@wixc3/simulation-core)
+
+This package exposes single simulation types, and methods for testing simulations.
+
+## Helpers
+
+### `simulationToJsx`
+
+```tsx
+function simulationToJsx(simulation: ISimulation): JSX.Element;
+```
+
+Takes a simulation and returns a JSX Element representing the component and its simulation props. It will be wrapped in wrapper if simulation contains one.
+
+### `setupSimulationStage`
+
+```tsx
+function setupSimulationStage(
+  simulation: ISimulation,
+  window?: HTMLElement
+): { canvas: HTMLElement; cleanup: () => void };
+```
+
+Takes a simulation, and optionally, a window to apply styles to. Styles will be applied to the global window if no window is provided.
+
+This method returns a canvas for rendering into, along with a cleanup method to unmount all components in the canvas, remove the canvas from the DOM, and reset any styling applied to the window.
+
+### `renderSimulation`
+
+```tsx
+function renderSimulation(simulation: ISimulation): { canvas: HTMLElement; cleanup: () => void };
+```
+
+Takes a simulation, and using ReactDOM, renders the result from the call to `simulationToJsx` into the canvas that was returned by `setupSimulationStage`. Note below that a cleanup method is also available.
+
+## Plugins
+
+Plugins can add more meta data, modify the rendering environment, wrap the render result and much more.
+Plugins are specific to a sub-type of `IGeneralMetadata` and can use the hooks supplied by the meta data type.
+
+For instance, `cssVarsPlugin` is only applicable to `IRenderable` and uses the `beforeRender` hook.
+
+### Built-in Plugins
+
+## tagPlugin
+
+Adds relevant tags to the simulation. Useful for indexing the simulations.
+
+## cssVarsPlugin
+
+Accepts a record containing css var names and values to give them during the simulation.
+Adds those css variables to the convas style.
+
+## Example plugin usage
+
+```tsx
+import { createSimulation } from '@wixc3/react-simulation';
+import { tagPlugin, cssVarsPlugin } from '@wixc3/simulation-core';
+import { AutoComplete } from './auto-complete';
+
+createSimulation({
+  name: 'some simulation',
+  props: { name: 'Joe' },
+  componentType: AutoComplete,
+  plugins: [
+    tagPlugin.use({
+      tags: ['react', 'forms', 'completions'],
+    }),
+    cssVarsPlugin.use({
+      '--label-color': 'red',
+    }),
+  ],
+});
+```
+
+## License
+
+MIT

--- a/packages/simulation-core/package.json
+++ b/packages/simulation-core/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@wixc3/simulation-core",
+  "description": "Types and helpers for component simulations",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "files": [
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}"
+  ],
+  "license": "MIT",
+  "repository": "https://github.com/wixplosives/wcs-core/tree/master/packages/simulation-core",
+  "homepage": "https://github.com/wixplosives/wcs-core",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/simulation-core/src/create-metadata.ts
+++ b/packages/simulation-core/src/create-metadata.ts
@@ -1,0 +1,8 @@
+import type { HookMap, IGeneralMetadata } from './types';
+export type OmitGeneralMetadata<DATA extends IGeneralMetadata<unknown, HookMap>> = Omit<DATA, '__hooks'>;
+
+export function createMetadata<DATA extends IGeneralMetadata<unknown, HookMap>>(
+    metadata: OmitGeneralMetadata<DATA>
+): DATA {
+    return metadata as DATA;
+}

--- a/packages/simulation-core/src/create-renderable-base.ts
+++ b/packages/simulation-core/src/create-renderable-base.ts
@@ -1,0 +1,28 @@
+import { createMetadata, OmitGeneralMetadata } from './create-metadata';
+import { callHooks, setupSimulationStage } from './render-helpers';
+import type { IRenderableMetadataBase } from './types';
+
+export type OmitIRenderableMetadataBase<DATA extends IRenderableMetadataBase> = Omit<
+    OmitGeneralMetadata<DATA>,
+    'setupStage' | 'cleanupStage'
+>;
+export function baseRender<DATA extends IRenderableMetadataBase>(
+    data: DATA,
+    render: (target: HTMLElement) => void,
+    canvas: HTMLElement
+): void {
+    callHooks<IRenderableMetadataBase, 'beforeRender'>(data, 'beforeRender', canvas);
+    render(canvas);
+    callHooks<IRenderableMetadataBase, 'afterRender'>(data, 'afterRender', canvas);
+}
+export function createRenderableBase<DATA extends IRenderableMetadataBase>(
+    data: OmitIRenderableMetadataBase<DATA>
+): DATA {
+    const res: DATA = createMetadata({
+        ...data,
+        setupStage() {
+            return setupSimulationStage(this);
+        },
+    } as DATA);
+    return res;
+}

--- a/packages/simulation-core/src/create-simulation-base.ts
+++ b/packages/simulation-core/src/create-simulation-base.ts
@@ -1,0 +1,12 @@
+import { createRenderableBase, OmitIRenderableMetadataBase } from './create-renderable-base';
+import type { HookMap, ISimulation } from './types';
+
+export type OmitSimulation<DATA extends ISimulation<unknown, unknown, HookMap>> = Omit<
+    OmitIRenderableMetadataBase<DATA>,
+    'target'
+>;
+export function createSimulationBase<DATA extends ISimulation<unknown, unknown, HookMap>>(
+    data: OmitSimulation<DATA>
+): DATA {
+    return createRenderableBase({ target: data.componentType, ...data } as DATA);
+}

--- a/packages/simulation-core/src/index.ts
+++ b/packages/simulation-core/src/index.ts
@@ -1,0 +1,7 @@
+export * from './types';
+export * from './render-helpers';
+export * from './create-metadata';
+export * from './create-renderable-base';
+export * from './create-simulation-base';
+export * from './plugins/css-vars-plugin';
+export * from './plugins/tags-plugin';

--- a/packages/simulation-core/src/plugins/css-vars-plugin.tsx
+++ b/packages/simulation-core/src/plugins/css-vars-plugin.tsx
@@ -1,0 +1,13 @@
+import { createPlugin, IRenderableMetadataBase } from '../types';
+
+export const cssVarsPlugin = createPlugin<IRenderableMetadataBase>()<{ [varName: string]: string }>(
+    'CSS Vars',
+    {},
+    {
+        beforeRender(props, canvas) {
+            for (const [varName, varValue] of Object.entries(props)) {
+                canvas.style.setProperty(varName, varValue);
+            }
+        },
+    }
+);

--- a/packages/simulation-core/src/plugins/tags-plugin.ts
+++ b/packages/simulation-core/src/plugins/tags-plugin.ts
@@ -1,0 +1,9 @@
+import { createPlugin } from '../types';
+
+export const tagPlugin = createPlugin()<{ tags: string[] }>(
+    'Tags',
+    {
+        tags: [],
+    },
+    {}
+);

--- a/packages/simulation-core/src/render-helpers.tsx
+++ b/packages/simulation-core/src/render-helpers.tsx
@@ -1,0 +1,162 @@
+import type {
+    SetupSimulationStage,
+    RenderSimulation,
+    IWindowEnvironmentProps,
+    ICanvasEnvironmentProps,
+    IGeneralMetadata,
+    PluginInfo,
+    Plugin,
+    HookMap,
+    IPROPS,
+    HOOK,
+} from './types';
+
+// const entries = Object.entries as <T>(o: T) => [Extract<keyof T, string>, T[keyof T]][];
+
+type CanvasStyles = Pick<
+    CSSStyleDeclaration,
+    | 'backgroundColor'
+    | 'height'
+    | 'width'
+    | 'paddingLeft'
+    | 'paddingRight'
+    | 'paddingBottom'
+    | 'paddingTop'
+    | 'marginLeft'
+    | 'marginRight'
+    | 'marginBottom'
+    | 'marginTop'
+>;
+
+const defaultCanvasStyles: CanvasStyles = {
+    width: 'fit-content',
+    height: 'fit-content',
+    marginLeft: '0px',
+    marginRight: '0px',
+    marginBottom: '0px',
+    marginTop: '0px',
+    paddingLeft: '0px',
+    paddingRight: '0px',
+    paddingBottom: '0px',
+    paddingTop: '0px',
+    backgroundColor: '#fff',
+};
+
+const applyStylesToWindow = (windowStyles: Partial<IWindowEnvironmentProps> = {}) => {
+    const oldWindowHeight = window.outerHeight;
+    const oldWindowWidth = window.outerWidth;
+    const oldBackgroundColor = document.body.style.backgroundColor;
+
+    window.resizeTo(windowStyles.windowWidth || oldWindowWidth, windowStyles.windowHeight || oldWindowHeight);
+    document.body.style.backgroundColor = windowStyles.windowBackgroundColor || oldBackgroundColor;
+
+    return () => {
+        window.resizeTo(oldWindowWidth, oldWindowHeight);
+        document.body.style.backgroundColor = oldBackgroundColor;
+    };
+};
+
+const mapEnvironmentPropsToStyles = (environmentProps: Partial<ICanvasEnvironmentProps>): CanvasStyles => ({
+    width: environmentProps.canvasWidth ? `${environmentProps.canvasWidth}px` : defaultCanvasStyles.width,
+    height: environmentProps.canvasHeight ? `${environmentProps.canvasHeight}px` : defaultCanvasStyles.height,
+    marginLeft: environmentProps.canvasMargin?.left
+        ? `${environmentProps.canvasMargin?.left}px`
+        : defaultCanvasStyles.marginLeft,
+    marginRight: environmentProps.canvasMargin?.right
+        ? `${environmentProps.canvasMargin?.right}px`
+        : defaultCanvasStyles.marginRight,
+    marginBottom: environmentProps.canvasMargin?.bottom
+        ? `${environmentProps.canvasMargin?.bottom}px`
+        : defaultCanvasStyles.marginBottom,
+    marginTop: environmentProps.canvasMargin?.top
+        ? `${environmentProps.canvasMargin?.top}px`
+        : defaultCanvasStyles.marginTop,
+    paddingLeft: environmentProps.canvasPadding?.left
+        ? `${environmentProps.canvasPadding?.left}px`
+        : defaultCanvasStyles.paddingLeft,
+    paddingRight: environmentProps.canvasPadding?.right
+        ? `${environmentProps.canvasPadding?.right}px`
+        : defaultCanvasStyles.paddingRight,
+    paddingBottom: environmentProps.canvasPadding?.bottom
+        ? `${environmentProps.canvasPadding?.bottom}px`
+        : defaultCanvasStyles.paddingBottom,
+    paddingTop: environmentProps.canvasPadding?.top
+        ? `${environmentProps.canvasPadding?.top}px`
+        : defaultCanvasStyles.paddingTop,
+    backgroundColor: environmentProps.canvasBackgroundColor || defaultCanvasStyles.backgroundColor,
+});
+
+const applyStylesToCanvas = (canvas: HTMLDivElement, canvasEnvironmentProps: Partial<ICanvasEnvironmentProps> = {}) => {
+    Object.assign(canvas.style, mapEnvironmentPropsToStyles(canvasEnvironmentProps));
+};
+export type HookNames<DATA extends IGeneralMetadata<unknown, HookMap>> = keyof NonNullable<DATA['__hooks']> & string;
+
+export function getPluginsWithHooks<DATA extends IGeneralMetadata<unknown, HookMap>>(
+    data: DATA,
+    hookName: HookNames<DATA>
+): PluginInfo<IPROPS, DATA, Plugin<IPROPS, DATA>>[] {
+    if (!data.plugins) {
+        return [];
+    }
+    return data.plugins.filter((item) => !!(item.key.plugin as HookMap)[hookName]) as PluginInfo<
+        IPROPS,
+        DATA,
+        Plugin<IPROPS, DATA>
+    >[];
+}
+
+export type HookParams<DATA extends IGeneralMetadata<unknown, HookMap>, HOOK extends HookNames<DATA>> = NonNullable<
+    NonNullable<DATA['__hooks']>[HOOK]
+> extends (pluginParams: never, ...args: infer U) => void | unknown
+    ? U
+    : never;
+
+export function callHooks<DATA extends IGeneralMetadata<unknown, HookMap>, HOOKNAME extends HookNames<DATA>>(
+    data: DATA,
+    hookName: HOOKNAME,
+    ...props: HookParams<DATA, HOOKNAME>
+): void {
+    const plugins = getPluginsWithHooks(data, hookName);
+    for (const pluginInfo of plugins) {
+        if ((pluginInfo.key.plugin as HookMap)[hookName]) {
+            (((pluginInfo.key.plugin as HookMap)[hookName] as unknown) as HOOK<
+                IPROPS,
+                HookParams<DATA, HOOKNAME>,
+                void
+            >)(pluginInfo.props as never, ...props);
+        }
+    }
+}
+
+export const setupSimulationStage: SetupSimulationStage = (simulation) => {
+    const canvas = document.createElement('div');
+    canvas.setAttribute('id', 'simulation-canvas');
+
+    const resetWindow = applyStylesToWindow(simulation.environmentProps);
+    applyStylesToCanvas(canvas, simulation.environmentProps);
+    callHooks(simulation, 'beforeAppendCanvas', canvas);
+
+    document.body.appendChild(canvas);
+
+    const cleanup = () => {
+        callHooks(simulation, 'beforeStageCleanUp', canvas);
+
+        canvas.remove();
+        resetWindow();
+    };
+
+    return { canvas, cleanup };
+};
+
+export const renderSimulation: RenderSimulation = (simulation) => {
+    const { canvas, cleanup: stageCleanup } = setupSimulationStage(simulation);
+    simulation.renderer(canvas);
+
+    return {
+        canvas,
+        cleanup: (): void => {
+            simulation.cleanup(canvas);
+            stageCleanup();
+        },
+    };
+};

--- a/packages/simulation-core/src/tsconfig.json
+++ b/packages/simulation-core/src/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist"
+  }
+}

--- a/packages/simulation-core/src/types.ts
+++ b/packages/simulation-core/src/types.ts
@@ -1,0 +1,169 @@
+export type LayoutSize = number | undefined | null;
+
+export type LayoutSizeWithAuto = LayoutSize | 'auto';
+
+export interface LayoutSpacing {
+    /** @visualizer spacing */
+    top?: LayoutSize;
+    /** @visualizer spacing */
+    right?: LayoutSize;
+    /** @visualizer spacing */
+    bottom?: LayoutSize;
+    /** @visualizer spacing */
+    left?: LayoutSize;
+}
+
+export type IPreviewEnvironmentPropsBase = IWindowEnvironmentProps & ICanvasEnvironmentProps;
+
+export interface IWindowEnvironmentProps {
+    /** @visualizer spacing */
+    windowWidth?: number | undefined;
+    /** @visualizer spacing */
+    windowHeight?: number | undefined;
+    /** @visualizer color */
+    windowBackgroundColor?: string | undefined;
+}
+
+export interface ICanvasEnvironmentProps {
+    /** @visualizer spacing */
+    canvasWidth?: LayoutSizeWithAuto;
+    /** @visualizer spacing */
+    canvasHeight?: LayoutSizeWithAuto;
+    /** @visualizer color */
+    canvasBackgroundColor?: string;
+    /** @visualizer canvasMargin */
+    canvasMargin?: LayoutSpacing;
+    /** @visualizer canvasPadding */
+    canvasPadding?: LayoutSpacing;
+}
+
+export interface IPROPS {
+    [propName: string]: unknown;
+}
+
+export type HOOK<PLUGINPARAMS extends IPROPS, HOOKPARAMS extends unknown[], RES> = (
+    params: PLUGINPARAMS,
+    ...hookParams: HOOKPARAMS
+) => RES;
+export interface HookMap<PLUGINPARAMS extends IPROPS = never> {
+    [hookName: string]: HOOK<PLUGINPARAMS, never[], unknown> | undefined;
+}
+
+export interface ISetupController {
+    addScript(scriptUrl: string): Promise<void>;
+    addStylesheet(stylesheetUrl: string): Promise<void>;
+}
+
+export type SimulationSetupFunction = (controller: ISetupController) => void | Promise<void>;
+
+export interface Plugin<PLUGINPARAMS extends IPROPS, TARGET extends IGeneralMetadata<unknown, HookMap>> {
+    pluginName: string;
+    defaultProps: Partial<PLUGINPARAMS>;
+    plugin: TARGET['__hooks'];
+    use: (props: Partial<PLUGINPARAMS>) => PluginInfo<PLUGINPARAMS, TARGET, Plugin<PLUGINPARAMS, TARGET>>;
+}
+export interface PluginInfo<
+    PLUGINPARAMS extends IPROPS,
+    TARGET extends IGeneralMetadata<unknown, HookMap>,
+    SYMB extends Plugin<PLUGINPARAMS, TARGET>
+> {
+    key: SYMB;
+    props: PLUGINPARAMS;
+}
+
+export type ReplaceParams<MAP extends HookMap, PARAMS extends IPROPS> = {
+    [hookname in keyof MAP]: NonNullable<MAP[hookname]> extends (
+        pProps: never,
+        ...params: infer HOOKPARAMS
+    ) => infer RES
+        ? HOOK<PARAMS, HOOKPARAMS, RES>
+        : never;
+};
+
+export const createPlugin = <
+    TARGET extends IGeneralMetadata<unknown, HookMap> = IGeneralMetadata<unknown, HookMap>
+>() => <PluginProps extends IPROPS>(
+    pluginName: string,
+    defaultProps: Partial<PluginProps>,
+    plugin: ReplaceParams<NonNullable<TARGET['__hooks']>, PluginProps>
+): Plugin<PluginProps, TARGET> => {
+    const res: Plugin<PluginProps, TARGET> = {
+        pluginName,
+        defaultProps,
+        plugin,
+        use: (props) => {
+            return {
+                key: (res as unknown) as Plugin<PluginProps, TARGET>,
+                props: { ...defaultProps, ...props } as PluginProps,
+            };
+        },
+    };
+    return res;
+};
+
+/** Describe entities in your project. */
+export interface IGeneralMetadata<TARGET, HOOKS extends HookMap = HookMap> {
+    target: TARGET;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    plugins?: PluginInfo<IPROPS, this, Plugin<any, this>>[];
+    __hooks?: HOOKS;
+}
+
+export interface IRenderableHooks<PLUGINPARAMS extends IPROPS = never> extends HookMap<PLUGINPARAMS> {
+    beforeAppendCanvas?(props: PLUGINPARAMS, canvas: HTMLElement): void;
+    beforeStageCleanUp?(props: PLUGINPARAMS, canvas: HTMLElement): void;
+    beforeRender?(pluginProps: PLUGINPARAMS, canvas: HTMLElement): void;
+    afterRender?(props: PLUGINPARAMS, canvas: HTMLElement): void;
+}
+export interface IRenderableMetadataBase<HOOKS extends HookMap = HookMap>
+    extends IGeneralMetadata<unknown, HOOKS & IRenderableHooks> {
+    /**
+     * renders the Renderable into an html element
+     */
+    renderer: (targetElement: HTMLElement) => void;
+    /**
+     * cleans everything the renderer does
+     */
+    cleanup: (targetElement: HTMLElement) => void;
+    /**
+     * sets the stage for the renderer.
+     * this function has many side effects ( such as effecting window styles and sizes )
+     *
+     * @returns canvas an html element for rendering into, cleanup a method for cleaing up the sideeffects
+     *
+     */
+    setupStage: () => { canvas: HTMLElement; cleanup: () => void };
+
+    /**
+     * Simulation's environment properties (e.g. the window size, the component alignment, etc.)
+     */
+    environmentProps?: IPreviewEnvironmentPropsBase;
+    /**
+     * Functions for setting up the page for the simulation: adding global styles,
+     * scripts, etc. These functions run only once before the simulation is mounted.
+     */
+    setup?: SimulationSetupFunction | SimulationSetupFunction[];
+}
+
+/**
+ * A single appearance of a component.
+ */
+export interface ISimulation<ComponentType, PROPS, HOOKS extends HookMap = HookMap>
+    extends IRenderableMetadataBase<HOOKS> {
+    /** The simulated component type. */
+    componentType: ComponentType;
+
+    /** The name of the simulation. */
+    name: string;
+
+    /**
+     * A map between a component property name and its simulated value.
+     */
+    props: PROPS;
+}
+
+export type SetupSimulationStage = (
+    simulation: IRenderableMetadataBase
+) => { canvas: HTMLElement; cleanup: () => void };
+
+export type RenderSimulation = (simulation: IRenderableMetadataBase) => { canvas: HTMLElement; cleanup: () => void };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,12 @@
 {
   "files": [],
-  "references": [{ "path": "./packages/wcs-core/src" }, { "path": "./packages/wcs-core/test" }]
+  "references": [
+    { "path": "./packages/wcs-core/src" },
+    { "path": "./packages/wcs-core/test" },
+
+    { "path": "./packages/simulation-core/src" },
+
+    { "path": "./packages/react-simulation/src" },
+    { "path": "./packages/react-simulation/test" }
+  ]
 }


### PR DESCRIPTION
Introduce `@wixc3/simulation-core` and `@wixc3/react-simulation` containing the changes of 2.1.0-2.2.0 separated into the different packages.