### PR TITLE
fix: append canvas to a provided parent element in setupStage

### DIFF
--- a/packages/simulation-core/src/create-renderable-base.ts
+++ b/packages/simulation-core/src/create-renderable-base.ts
@@ -23,8 +23,8 @@ export function createRenderableBase<DATA extends IRenderableMetadataBase>(
 ): DATA {
     const res: DATA = createMetadata({
         ...data,
-        setupStage() {
-            return setupSimulationStage(this);
+        setupStage(parentElement: HTMLElement = document.body) {
+            return setupSimulationStage(this, parentElement);
         },
     } as DATA);
     return res;

--- a/packages/simulation-core/src/setup-stage.tsx
+++ b/packages/simulation-core/src/setup-stage.tsx
@@ -1,35 +1,6 @@
 import { callHooks } from './hooks';
 import type { SetupSimulationStage, IWindowEnvironmentProps, ICanvasEnvironmentProps } from './types';
 
-type CanvasStyles = Pick<
-    CSSStyleDeclaration,
-    | 'backgroundColor'
-    | 'height'
-    | 'width'
-    | 'paddingLeft'
-    | 'paddingRight'
-    | 'paddingBottom'
-    | 'paddingTop'
-    | 'marginLeft'
-    | 'marginRight'
-    | 'marginBottom'
-    | 'marginTop'
->;
-
-const defaultCanvasStyles: CanvasStyles = {
-    width: 'fit-content',
-    height: 'fit-content',
-    marginLeft: '0px',
-    marginRight: '0px',
-    marginBottom: '0px',
-    marginTop: '0px',
-    paddingLeft: '0px',
-    paddingRight: '0px',
-    paddingBottom: '0px',
-    paddingTop: '0px',
-    backgroundColor: '#fff',
-};
-
 const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}) => {
     const oldWindowHeight = window.outerHeight;
     const oldWindowWidth = window.outerWidth;
@@ -44,47 +15,16 @@ const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}) => {
     };
 };
 
-const calculateCanvasStyle = (environmentProps: ICanvasEnvironmentProps = {}): CanvasStyles => ({
-    width: environmentProps.canvasWidth ? `${environmentProps.canvasWidth}px` : defaultCanvasStyles.width,
-    height: environmentProps.canvasHeight ? `${environmentProps.canvasHeight}px` : defaultCanvasStyles.height,
-    marginLeft: environmentProps.canvasMargin?.left
-        ? `${environmentProps.canvasMargin?.left}px`
-        : defaultCanvasStyles.marginLeft,
-    marginRight: environmentProps.canvasMargin?.right
-        ? `${environmentProps.canvasMargin?.right}px`
-        : defaultCanvasStyles.marginRight,
-    marginBottom: environmentProps.canvasMargin?.bottom
-        ? `${environmentProps.canvasMargin?.bottom}px`
-        : defaultCanvasStyles.marginBottom,
-    marginTop: environmentProps.canvasMargin?.top
-        ? `${environmentProps.canvasMargin?.top}px`
-        : defaultCanvasStyles.marginTop,
-    paddingLeft: environmentProps.canvasPadding?.left
-        ? `${environmentProps.canvasPadding?.left}px`
-        : defaultCanvasStyles.paddingLeft,
-    paddingRight: environmentProps.canvasPadding?.right
-        ? `${environmentProps.canvasPadding?.right}px`
-        : defaultCanvasStyles.paddingRight,
-    paddingBottom: environmentProps.canvasPadding?.bottom
-        ? `${environmentProps.canvasPadding?.bottom}px`
-        : defaultCanvasStyles.paddingBottom,
-    paddingTop: environmentProps.canvasPadding?.top
-        ? `${environmentProps.canvasPadding?.top}px`
-        : defaultCanvasStyles.paddingTop,
-    backgroundColor: environmentProps.canvasBackgroundColor || defaultCanvasStyles.backgroundColor,
-});
-
-export const setupSimulationStage: SetupSimulationStage = (simulation) => {
+export const setupSimulationStage: SetupSimulationStage = (simulation, parentElement) => {
     const canvas = document.createElement('div');
     canvas.setAttribute('id', 'simulation-canvas');
 
     const { environmentProps } = simulation;
     const resetWindow = applyStylesToWindow(environmentProps);
-    Object.assign(canvas.style, calculateCanvasStyle(environmentProps));
 
     callHooks(simulation, 'beforeAppendCanvas', canvas);
 
-    document.body.appendChild(canvas);
+    parentElement.appendChild(canvas);
 
     const cleanup = () => {
         callHooks(simulation, 'beforeStageCleanUp', canvas);

--- a/packages/simulation-core/src/setup-stage.tsx
+++ b/packages/simulation-core/src/setup-stage.tsx
@@ -1,5 +1,5 @@
 import { callHooks } from './hooks';
-import type { SetupSimulationStage, IWindowEnvironmentProps, ICanvasEnvironmentProps } from './types';
+import type { SetupSimulationStage, IWindowEnvironmentProps } from './types';
 
 const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}) => {
     const oldWindowHeight = window.outerHeight;

--- a/packages/simulation-core/src/types.ts
+++ b/packages/simulation-core/src/types.ts
@@ -138,7 +138,7 @@ export interface IRenderableMetadataBase<HOOKS extends HookMap = HookMap>
      * @returns canvas an html element for rendering into, cleanup a method for cleaing up the sideeffects
      *
      */
-    setupStage: () => { canvas: HTMLElement; cleanup: () => void };
+    setupStage: (parentElement?: HTMLElement) => { canvas: HTMLElement; cleanup: () => void };
 
     /**
      * Simulation's environment properties (e.g. the window size, the component alignment, etc.)
@@ -167,7 +167,10 @@ export interface ISimulation<ComponentType, P, HOOKS extends HookMap = HookMap> 
     props: P;
 }
 
-export type SetupSimulationStage = (simulation: IRenderableMetadataBase) => {
+export type SetupSimulationStage = (
+    simulation: IRenderableMetadataBase,
+    parentElement: HTMLElement
+) => {
     canvas: HTMLElement;
     cleanup: () => void;
 };


### PR DESCRIPTION
Currently, the "canvas" is appended automatically to the `document.body`. This PR adds the option to provide a specific parent element to append the canvas to.
Canvas styling was removed as well as it's styled externally.