### PR TITLE
refactor: setup-stage

### DIFF
--- a/packages/react-simulation/test/setup-stage.spec.tsx
+++ b/packages/react-simulation/test/setup-stage.spec.tsx
@@ -6,7 +6,7 @@ import { setupSimulationStage } from '@wixc3/simulation-core';
 const CONTAINER_HEIGHT = 50;
 
 describe('setup-stage', () => {
-    it('renders canvas to parent element', () => {
+    it('renders the canvas into a parent element', () => {
         const container = createCanvasContainer();
 
         const { canvas } = setupSimulationStage(
@@ -44,7 +44,7 @@ describe('setup-stage', () => {
         expect(canvas?.offsetWidth).equal(canvasSize.canvasWidth);
     });
 
-    it('sets canvas height to auto if a top and bottom margin is provided', () => {
+    it('sets canvas height to auto if a "top" and "bottom" margin is provided', () => {
         const container = createCanvasContainer();
 
         const { canvas, updateCanvas } = setupSimulationStage(
@@ -61,7 +61,7 @@ describe('setup-stage', () => {
         expect(canvas?.offsetHeight).equal(CONTAINER_HEIGHT - 2 * 5);
     });
 
-    it('sets canvas width to auto if a left and right margin is provided', () => {
+    it('sets canvas width to auto if "left" and "right" margin is provided', () => {
         const container = createCanvasContainer();
 
         const { canvas, updateCanvas } = setupSimulationStage(

--- a/packages/react-simulation/test/setup-stage.spec.tsx
+++ b/packages/react-simulation/test/setup-stage.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { expect } from 'chai';
 import { createSimulation } from '@wixc3/react-simulation';
 import { setupSimulationStage } from '@wixc3/simulation-core';
@@ -14,10 +13,10 @@ describe('setup-stage', () => {
         cleanupAfterTest.clear();
     });
 
-    it('renders the canvas into a parent element', () => {
+    function setupSimulation() {
         const container = createCanvasContainer();
 
-        const { canvas, cleanup } = setupSimulationStage(
+        const { canvas, cleanup, updateCanvas, updateWindow } = setupSimulationStage(
             createSimulation({
                 name: 'Test1',
                 props: {},
@@ -27,21 +26,17 @@ describe('setup-stage', () => {
         );
 
         cleanupAfterTest.add(cleanup);
-        expect(canvas.parentElement).to.eql(container);
+
+        return { canvas, container, updateWindow, updateCanvas };
+    }
+
+    it('renders the canvas into a parent element', () => {
+        const { canvas, container } = setupSimulation();
+        expect(canvas.parentElement, 'canvas was not rendered into a provided container').to.eql(container);
     });
 
     it('sets canvas height and canvas width to the provided values if no margin is provided', () => {
-        const container = createCanvasContainer();
-
-        const { canvas, updateCanvas, cleanup } = setupSimulationStage(
-            createSimulation({
-                name: 'Test1',
-                props: {},
-                componentType: () => null,
-            }),
-            container
-        );
-        cleanupAfterTest.add(cleanup);
+        const { updateCanvas, canvas } = setupSimulation();
 
         const canvasSize = { canvasHeight: 690, canvasWidth: 420 };
 
@@ -50,44 +45,56 @@ describe('setup-stage', () => {
             canvasHeight: canvasSize.canvasHeight,
         });
 
-        expect(canvas?.offsetHeight).equal(canvasSize.canvasHeight);
-        expect(canvas?.offsetWidth).equal(canvasSize.canvasWidth);
+        expect(canvas?.offsetHeight, 'canvas height was not updated').equal(canvasSize.canvasHeight);
+        expect(canvas?.offsetWidth, 'canvas width was not updated').equal(canvasSize.canvasWidth);
     });
 
     it('sets canvas height to auto if a "top" and "bottom" margin is provided', () => {
-        const container = createCanvasContainer();
-
-        const { canvas, cleanup, updateCanvas } = setupSimulationStage(
-            createSimulation({
-                name: 'Test1',
-                props: {},
-                componentType: () => <>123</>,
-            }),
-            container
-        );
-        cleanupAfterTest.add(cleanup);
+        const { updateCanvas, canvas } = setupSimulation();
 
         updateCanvas({ canvasHeight: 5, canvasMargin: { top: 5, bottom: 5 } });
 
-        expect(canvas?.offsetHeight).equal(CONTAINER_HEIGHT - 2 * 5);
+        expect(canvas?.offsetHeight, 'canvas height is not stretched when margins are applied').equal(
+            CONTAINER_HEIGHT - 2 * 5
+        );
     });
 
     it('sets canvas width to auto if "left" and "right" margin is provided', () => {
-        const container = createCanvasContainer();
-
-        const { canvas, updateCanvas, cleanup } = setupSimulationStage(
-            createSimulation({
-                name: 'Test1',
-                props: {},
-                componentType: () => null,
-            }),
-            container
-        );
-        cleanupAfterTest.add(cleanup);
+        const { updateCanvas, canvas } = setupSimulation();
 
         updateCanvas({ canvasWidth: 5, canvasMargin: { left: 5, right: 5 } });
 
-        expect(canvas?.offsetWidth).equal(window.innerWidth - 2 * 5);
+        expect(canvas?.offsetWidth, 'canvas width is not stretched when margins are applied').equal(
+            window.innerWidth - 2 * 5
+        );
+    });
+
+    it('sets canvas background color', () => {
+        const { updateCanvas, canvas } = setupSimulation();
+
+        updateCanvas({ canvasBackgroundColor: '#fff' });
+
+        expect(window.getComputedStyle(canvas).backgroundColor, 'canvas background color was not updated').equal(
+            'rgb(255, 255, 255)'
+        );
+    });
+
+    it('sets window dimensions', () => {
+        const { updateWindow } = setupSimulation();
+
+        updateWindow({ windowHeight: 500, windowWidth: 500 });
+
+        expect(window.outerHeight, 'window width was not updated').to.eql(500);
+        expect(window.outerWidth, 'window height was not updated').to.eql(500);
+    });
+
+    it('sets window background color', () => {
+        const { updateWindow } = setupSimulation();
+
+        updateWindow({ windowBackgroundColor: '#fff' });
+        expect(window.getComputedStyle(document.body).backgroundColor, 'window background color was not updated').equal(
+            'rgb(255, 255, 255)'
+        );
     });
 });
 

--- a/packages/react-simulation/test/setup-stage.spec.tsx
+++ b/packages/react-simulation/test/setup-stage.spec.tsx
@@ -34,6 +34,7 @@ describe('setup-stage', () => {
         );
 
         const canvasSize = { canvasHeight: 690, canvasWidth: 420 };
+
         updateCanvas({
             canvasWidth: canvasSize.canvasWidth,
             canvasHeight: canvasSize.canvasHeight,
@@ -56,6 +57,7 @@ describe('setup-stage', () => {
         );
 
         updateCanvas({ canvasHeight: 5, canvasMargin: { top: 5, bottom: 5 } });
+
         expect(canvas?.offsetHeight).equal(CONTAINER_HEIGHT - 2 * 5);
     });
 

--- a/packages/react-simulation/test/setup-stage.spec.tsx
+++ b/packages/react-simulation/test/setup-stage.spec.tsx
@@ -4,7 +4,7 @@ import { setupSimulationStage } from '@wixc3/simulation-core';
 
 const CONTAINER_HEIGHT = 50;
 
-describe('setup-stage', () => {
+describe('setup stage', () => {
     const cleanupAfterTest = new Set<() => unknown>();
     afterEach(() => {
         for (const cleanup of cleanupAfterTest) {

--- a/packages/react-simulation/test/setup-stage.spec.tsx
+++ b/packages/react-simulation/test/setup-stage.spec.tsx
@@ -6,10 +6,18 @@ import { setupSimulationStage } from '@wixc3/simulation-core';
 const CONTAINER_HEIGHT = 50;
 
 describe('setup-stage', () => {
+    const cleanupAfterTest = new Set<() => unknown>();
+    afterEach(() => {
+        for (const cleanup of cleanupAfterTest) {
+            cleanup();
+        }
+        cleanupAfterTest.clear();
+    });
+
     it('renders the canvas into a parent element', () => {
         const container = createCanvasContainer();
 
-        const { canvas } = setupSimulationStage(
+        const { canvas, cleanup } = setupSimulationStage(
             createSimulation({
                 name: 'Test1',
                 props: {},
@@ -18,13 +26,14 @@ describe('setup-stage', () => {
             container
         );
 
+        cleanupAfterTest.add(cleanup);
         expect(canvas.parentElement).to.eql(container);
     });
 
     it('sets canvas height and canvas width to the provided values if no margin is provided', () => {
         const container = createCanvasContainer();
 
-        const { canvas, updateCanvas } = setupSimulationStage(
+        const { canvas, updateCanvas, cleanup } = setupSimulationStage(
             createSimulation({
                 name: 'Test1',
                 props: {},
@@ -32,6 +41,7 @@ describe('setup-stage', () => {
             }),
             container
         );
+        cleanupAfterTest.add(cleanup);
 
         const canvasSize = { canvasHeight: 690, canvasWidth: 420 };
 
@@ -47,7 +57,7 @@ describe('setup-stage', () => {
     it('sets canvas height to auto if a "top" and "bottom" margin is provided', () => {
         const container = createCanvasContainer();
 
-        const { canvas, updateCanvas } = setupSimulationStage(
+        const { canvas, cleanup, updateCanvas } = setupSimulationStage(
             createSimulation({
                 name: 'Test1',
                 props: {},
@@ -55,6 +65,7 @@ describe('setup-stage', () => {
             }),
             container
         );
+        cleanupAfterTest.add(cleanup);
 
         updateCanvas({ canvasHeight: 5, canvasMargin: { top: 5, bottom: 5 } });
 
@@ -64,7 +75,7 @@ describe('setup-stage', () => {
     it('sets canvas width to auto if "left" and "right" margin is provided', () => {
         const container = createCanvasContainer();
 
-        const { canvas, updateCanvas } = setupSimulationStage(
+        const { canvas, updateCanvas, cleanup } = setupSimulationStage(
             createSimulation({
                 name: 'Test1',
                 props: {},
@@ -72,6 +83,7 @@ describe('setup-stage', () => {
             }),
             container
         );
+        cleanupAfterTest.add(cleanup);
 
         updateCanvas({ canvasWidth: 5, canvasMargin: { left: 5, right: 5 } });
 

--- a/packages/react-simulation/test/setup-stage.spec.tsx
+++ b/packages/react-simulation/test/setup-stage.spec.tsx
@@ -84,8 +84,8 @@ describe('setup-stage', () => {
 
         updateWindow({ windowHeight: 500, windowWidth: 500 });
 
-        expect(window.outerHeight, 'window width was not updated').to.eql(500);
-        expect(window.outerWidth, 'window height was not updated').to.eql(500);
+        expect(window.outerHeight, 'window height was not updated').to.eql(500);
+        expect(window.outerWidth, 'window width was not updated').to.eql(500);
     });
 
     it('sets window background color', () => {

--- a/packages/react-simulation/test/setup-stage.spec.tsx
+++ b/packages/react-simulation/test/setup-stage.spec.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { expect } from 'chai';
+import { createSimulation } from '@wixc3/react-simulation';
+import { setupSimulationStage } from '@wixc3/simulation-core';
+
+const CONTAINER_HEIGHT = 50;
+
+describe('setup-stage', () => {
+    it('renders canvas to parent element', () => {
+        const container = createCanvasContainer();
+
+        const { canvas } = setupSimulationStage(
+            createSimulation({
+                name: 'Test1',
+                props: {},
+                componentType: () => null,
+            }),
+            container
+        );
+
+        expect(canvas.parentElement).to.eql(container);
+    });
+
+    it('sets canvas height and canvas width to the provided values if no margin is provided', () => {
+        const container = createCanvasContainer();
+
+        const { canvas, updateCanvas } = setupSimulationStage(
+            createSimulation({
+                name: 'Test1',
+                props: {},
+                componentType: () => null,
+            }),
+            container
+        );
+
+        const canvasSize = { canvasHeight: 690, canvasWidth: 420 };
+        updateCanvas({
+            canvasWidth: canvasSize.canvasWidth,
+            canvasHeight: canvasSize.canvasHeight,
+        });
+
+        expect(canvas?.offsetHeight).equal(canvasSize.canvasHeight);
+        expect(canvas?.offsetWidth).equal(canvasSize.canvasWidth);
+    });
+
+    it('sets canvas height to auto if a top and bottom margin is provided', () => {
+        const container = createCanvasContainer();
+
+        const { canvas, updateCanvas } = setupSimulationStage(
+            createSimulation({
+                name: 'Test1',
+                props: {},
+                componentType: () => <>123</>,
+            }),
+            container
+        );
+
+        updateCanvas({ canvasHeight: 5, canvasMargin: { top: 5, bottom: 5 } });
+        expect(canvas?.offsetHeight).equal(CONTAINER_HEIGHT - 2 * 5);
+    });
+
+    it('sets canvas width to auto if a left and right margin is provided', () => {
+        const container = createCanvasContainer();
+
+        const { canvas, updateCanvas } = setupSimulationStage(
+            createSimulation({
+                name: 'Test1',
+                props: {},
+                componentType: () => null,
+            }),
+            container
+        );
+
+        updateCanvas({ canvasWidth: 5, canvasMargin: { left: 5, right: 5 } });
+
+        expect(canvas?.offsetWidth).equal(window.innerWidth - 2 * 5);
+    });
+});
+
+function createCanvasContainer() {
+    const container = document.createElement('div');
+    container.style.display = 'flex';
+    container.style.height = `${CONTAINER_HEIGHT}px`;
+    document.body.appendChild(container);
+    return container;
+}

--- a/packages/simulation-core/src/create-renderable-base.ts
+++ b/packages/simulation-core/src/create-renderable-base.ts
@@ -23,8 +23,8 @@ export function createRenderableBase<DATA extends IRenderableMetadataBase>(
 ): DATA {
     const res: DATA = createMetadata({
         ...data,
-        setupStage() {
-            return setupSimulationStage(this);
+        setupStage(parentElement = document.body) {
+            return setupSimulationStage(this, parentElement);
         },
     } as DATA);
     return res;

--- a/packages/simulation-core/src/index.ts
+++ b/packages/simulation-core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './create-metadata';
 export * from './create-renderable-base';
 export * from './create-simulation-base';
+export * from './setup-stage';
 export * from './hooks';
 export * from './types';

--- a/packages/simulation-core/src/setup-stage.tsx
+++ b/packages/simulation-core/src/setup-stage.tsx
@@ -80,7 +80,6 @@ const applyStylesToCanvas = (canvas: HTMLDivElement, environmentProps: ICanvasEn
 
     // Canvas gets stretched horizontally/vertically
     // when vertical (top and bottom) or horizontal (left and right) margins are applied.
-
     if (environmentProps.canvasMargin?.left !== undefined && environmentProps.canvasMargin.right !== undefined) {
         canvasStyle.width = '100%';
     }

--- a/packages/simulation-core/src/setup-stage.tsx
+++ b/packages/simulation-core/src/setup-stage.tsx
@@ -78,7 +78,7 @@ const applyStylesToCanvas = (canvas: HTMLDivElement, environmentProps: ICanvasEn
     };
 
     // Canvas gets stretched horizontally/vertically
-    // when vertical (top and bottom) or horizontal (left and right) margins are applied.
+    // when horizontal (left and right) or vertical (top and bottom) margins are applied.
     if (environmentProps.canvasMargin?.left !== undefined && environmentProps.canvasMargin.right !== undefined) {
         canvasStyle.width = '100%';
     }

--- a/packages/simulation-core/src/setup-stage.tsx
+++ b/packages/simulation-core/src/setup-stage.tsx
@@ -24,13 +24,14 @@ export const defaultCanvasStyles: CanvasStyles = {
 export const defaultEnvironmentProperties = {
     windowWidth: defaultWindowStyles.width,
     windowHeight: defaultWindowStyles.height,
-    windowBackgroundColor: '#fcfcfc',
+    windowBackgroundColor: defaultWindowStyles.backgroundColor,
     canvasMargin: {},
     canvasPadding: {},
-    canvasBackgroundColor: '#fff',
+    canvasBackgroundColor: defaultCanvasStyles.backgroundColor,
 };
 
 const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}, previousProps: IWindowEnvironmentProps) => {
+    // we revert the changes to previous values when running cleanup
     previousProps.windowHeight = previousProps.windowHeight ? window.outerHeight : defaultWindowStyles.height;
     previousProps.windowWidth = previousProps.windowWidth ? window.outerWidth : defaultWindowStyles.width;
     previousProps.windowBackgroundColor = previousProps.windowBackgroundColor

--- a/packages/simulation-core/src/setup-stage.tsx
+++ b/packages/simulation-core/src/setup-stage.tsx
@@ -1,22 +1,13 @@
 import { callHooks } from './hooks';
-import type { SetupSimulationStage, IWindowEnvironmentProps, ICanvasEnvironmentProps } from './types';
+import type { SetupSimulationStage, IWindowEnvironmentProps, ICanvasEnvironmentProps, CanvasStyles } from './types';
 
-type CanvasStyles = Pick<
-    CSSStyleDeclaration,
-    | 'backgroundColor'
-    | 'height'
-    | 'width'
-    | 'paddingLeft'
-    | 'paddingRight'
-    | 'paddingBottom'
-    | 'paddingTop'
-    | 'marginLeft'
-    | 'marginRight'
-    | 'marginBottom'
-    | 'marginTop'
->;
+export const defaultWindowStyles = {
+    width: 1024,
+    height: 640,
+    backgroundColor: '#fcfcfc',
+} as const;
 
-const defaultCanvasStyles: CanvasStyles = {
+export const defaultCanvasStyles: CanvasStyles = {
     width: 'fit-content',
     height: 'fit-content',
     marginLeft: 'auto',
@@ -28,23 +19,30 @@ const defaultCanvasStyles: CanvasStyles = {
     paddingBottom: '0px',
     paddingTop: '0px',
     backgroundColor: '#fff',
+} as const;
+
+export const defaultEnvironmentProperties = {
+    windowWidth: defaultWindowStyles.width,
+    windowHeight: defaultWindowStyles.height,
+    windowBackgroundColor: '#fcfcfc',
+    canvasMargin: {},
+    canvasPadding: {},
+    canvasBackgroundColor: '#fff',
 };
 
-const applyStylesToWindow = (
-    windowStyles: IWindowEnvironmentProps = {},
-    previousWindowEnvironmentProps: IWindowEnvironmentProps
-) => {
-    previousWindowEnvironmentProps.windowHeight = window.outerHeight;
-    previousWindowEnvironmentProps.windowWidth = window.outerWidth;
-    previousWindowEnvironmentProps.windowBackgroundColor = document.body.style.backgroundColor;
+const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}, previousProps: IWindowEnvironmentProps) => {
+    previousProps.windowHeight = previousProps.windowHeight ? window.outerHeight : defaultWindowStyles.height;
+    previousProps.windowWidth = previousProps.windowWidth ? window.outerWidth : defaultWindowStyles.width;
+    previousProps.windowBackgroundColor = previousProps.windowBackgroundColor
+        ? document.body.style.backgroundColor
+        : defaultWindowStyles.backgroundColor;
 
     window.resizeTo(
-        windowStyles.windowWidth || previousWindowEnvironmentProps.windowWidth,
-        windowStyles.windowHeight || previousWindowEnvironmentProps.windowHeight
+        windowStyles.windowWidth || previousProps.windowWidth,
+        windowStyles.windowHeight || previousProps.windowHeight
     );
 
-    document.body.style.backgroundColor =
-        windowStyles.windowBackgroundColor || previousWindowEnvironmentProps.windowBackgroundColor;
+    document.body.style.backgroundColor = windowStyles.windowBackgroundColor || previousProps.windowBackgroundColor;
 };
 
 const applyStylesToCanvas = (canvas: HTMLDivElement, environmentProps: ICanvasEnvironmentProps = {}) => {

--- a/packages/simulation-core/src/types.ts
+++ b/packages/simulation-core/src/types.ts
@@ -138,7 +138,7 @@ export interface IRenderableMetadataBase<HOOKS extends HookMap = HookMap>
      * @returns canvas an html element for rendering into, cleanup a method for cleaing up the sideeffects
      *
      */
-    setupStage: () => { canvas: HTMLElement; cleanup: () => void };
+    setupStage: (parentElement?: HTMLElement) => ReturnType<SetupSimulationStage>;
 
     /**
      * Simulation's environment properties (e.g. the window size, the component alignment, etc.)
@@ -167,7 +167,12 @@ export interface ISimulation<ComponentType, P, HOOKS extends HookMap = HookMap> 
     props: P;
 }
 
-export type SetupSimulationStage = (simulation: IRenderableMetadataBase) => {
+export type SetupSimulationStage = (
+    simulation: IRenderableMetadataBase,
+    parentElement: HTMLElement
+) => {
     canvas: HTMLElement;
     cleanup: () => void;
+    updateCanvas: (canvasEnvironmentProps: ICanvasEnvironmentProps) => void;
+    updateWindow: (windowEnvironmentProps: IWindowEnvironmentProps) => void;
 };

--- a/packages/simulation-core/src/types.ts
+++ b/packages/simulation-core/src/types.ts
@@ -176,3 +176,18 @@ export type SetupSimulationStage = (
     updateCanvas: (canvasEnvironmentProps: ICanvasEnvironmentProps) => void;
     updateWindow: (windowEnvironmentProps: IWindowEnvironmentProps) => void;
 };
+
+export type CanvasStyles = Pick<
+    CSSStyleDeclaration,
+    | 'backgroundColor'
+    | 'height'
+    | 'width'
+    | 'paddingLeft'
+    | 'paddingRight'
+    | 'paddingBottom'
+    | 'paddingTop'
+    | 'marginLeft'
+    | 'marginRight'
+    | 'marginBottom'
+    | 'marginTop'
+>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./packages/wcs-core/test" },
 
     { "path": "./packages/simulation-core/src" },
+
     { "path": "./packages/simulation-plugins/src" },
     { "path": "./packages/simulation-plugins/test" },
 


### PR DESCRIPTION
Refactor `simulation.setupStage` function.

- Enable passing a parent element as a container for the canvas element.
- return `updateCanvas` and `updateWindow` functions for manipulating `window` and `canvas` styles in addition to the `canvas` element and `cleanup` function.
-  Change the canvas dimensions once vertical/horizontal margins are applied.