### PR TITLE
BREAKING!: remove private: true from packages

### DIFF
--- a/packages/board-core/package.json
+++ b/packages/board-core/package.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "repository": "https://github.com/wixplosives/wcs-core/tree/master/packages/board-core",
   "homepage": "https://github.com/wixplosives/wcs-core",
-  "private": true,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/board-plugins/package.json
+++ b/packages/board-plugins/package.json
@@ -15,7 +15,6 @@
   },
   "repository": "https://github.com/wixplosives/wcs-core/tree/master/packages/board-plugins",
   "homepage": "https://github.com/wixplosives/wcs-core",
-  "private": true,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/react-board/package.json
+++ b/packages/react-board/package.json
@@ -19,7 +19,6 @@
   "license": "MIT",
   "repository": "https://github.com/wixplosives/wcs-core/tree/master/packages/react-board",
   "homepage": "https://github.com/wixplosives/wcs-core",
-  "private": true,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/react-board/src/create-board.tsx
+++ b/packages/react-board/src/create-board.tsx
@@ -1,29 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {
-    getPluginsWithHooks,
-    baseRender,
-    IRenderableLifeCycleHooks,
-    IRenderableMetadataBase,
-    OmitIRenderableMetadataBase,
-    createRenderableBase,
-} from '@wixc3/board-core';
+import { getPluginsWithHooks, baseRender, createRenderableBase } from '@wixc3/board-core';
 import { reactErrorHandledRendering } from './react-error-handled-render';
-
-export type OmitReactBoard<DATA extends IReactBoard> = Omit<
-    OmitIRenderableMetadataBase<DATA>,
-    'render' | 'cleanup' | 'props'
->;
-
-export interface IReactBoard extends IRenderableMetadataBase<IReactBoardHooks<never>> {
-    /** The name of the board. */
-    name: string;
-
-    /**
-     * the board to render
-     */
-    Board: React.ComponentType;
-}
+import type { IReactBoard, OmitReactBoard } from './types';
 
 export function createBoard(input: OmitReactBoard<IReactBoard>): IReactBoard {
     const res: IReactBoard = createRenderableBase<IReactBoard>({
@@ -50,13 +29,4 @@ export function createBoard(input: OmitReactBoard<IReactBoard>): IReactBoard {
         },
     });
     return res;
-}
-
-export interface IReactBoardHooks<PLUGINPROPS> extends IRenderableLifeCycleHooks<PLUGINPROPS> {
-    wrapRender?: (
-        props: PLUGINPROPS,
-        renderable: IRenderableMetadataBase,
-        renderableElement: JSX.Element,
-        canvas: HTMLElement
-    ) => null | JSX.Element;
 }

--- a/packages/react-board/src/index.ts
+++ b/packages/react-board/src/index.ts
@@ -1,1 +1,2 @@
 export * from './create-board';
+export * from './types';

--- a/packages/react-board/src/types.ts
+++ b/packages/react-board/src/types.ts
@@ -1,0 +1,30 @@
+import type {
+    IRenderableLifeCycleHooks,
+    IRenderableMetadataBase,
+    OmitIRenderableMetadataBase,
+} from '@wixc3/board-core';
+export { BoardSetupFunction } from '@wixc3/board-core';
+
+export type OmitReactBoard<DATA extends IReactBoard> = Omit<
+    OmitIRenderableMetadataBase<DATA>,
+    'render' | 'cleanup' | 'props'
+>;
+
+export interface IReactBoardHooks<PLUGINPROPS> extends IRenderableLifeCycleHooks<PLUGINPROPS> {
+    wrapRender?: (
+        props: PLUGINPROPS,
+        renderable: IRenderableMetadataBase,
+        renderableElement: JSX.Element,
+        canvas: HTMLElement
+    ) => null | JSX.Element;
+}
+
+export interface IReactBoard extends IRenderableMetadataBase<IReactBoardHooks<never>> {
+    /** The name of the board. */
+    name: string;
+
+    /**
+     * the board to render
+     */
+    Board: React.ComponentType;
+}


### PR DESCRIPTION
This will publish these packages.

Also added a re-export for `BoardSetupFunction` in react-board