### PR TITLE
fix(board-core): Removing window/canvas default background-colors

### DIFF
--- a/packages/board-core/src/setup-stage.tsx
+++ b/packages/board-core/src/setup-stage.tsx
@@ -34,9 +34,6 @@ const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}, previou
     // we revert the changes to previous values when running cleanup
     previousProps.windowHeight = previousProps.windowHeight ? window.outerHeight : defaultWindowStyles.height;
     previousProps.windowWidth = previousProps.windowWidth ? window.outerWidth : defaultWindowStyles.width;
-    previousProps.windowBackgroundColor = previousProps.windowBackgroundColor
-        ? document.body.style.backgroundColor
-        : defaultWindowStyles.backgroundColor;
 
     window.resizeTo(
         windowStyles.windowWidth || previousProps.windowWidth,
@@ -118,10 +115,6 @@ export const setupBoardStage: BoardSetupStageFunction = (board, parentElement) =
 
         if (previousWindowEnvironmentProps.windowWidth && previousWindowEnvironmentProps.windowHeight) {
             window.resizeTo(previousWindowEnvironmentProps.windowWidth, previousWindowEnvironmentProps.windowHeight);
-        }
-
-        if (previousWindowEnvironmentProps.windowBackgroundColor) {
-            document.body.style.backgroundColor = previousWindowEnvironmentProps.windowBackgroundColor;
         }
     };
 

--- a/packages/board-core/src/setup-stage.tsx
+++ b/packages/board-core/src/setup-stage.tsx
@@ -43,7 +43,7 @@ const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}, previou
         windowStyles.windowHeight || previousProps.windowHeight
     );
 
-    document.body.style.backgroundColor = windowStyles.windowBackgroundColor || previousProps.windowBackgroundColor;
+    document.body.style.backgroundColor = windowStyles.windowBackgroundColor || '';
 };
 
 const applyStylesToCanvas = (canvas: HTMLDivElement, environmentProps: ICanvasEnvironmentProps = {}) => {

--- a/packages/board-core/src/setup-stage.tsx
+++ b/packages/board-core/src/setup-stage.tsx
@@ -4,7 +4,6 @@ import type { BoardSetupStageFunction, IWindowEnvironmentProps, ICanvasEnvironme
 export const defaultWindowStyles = {
     width: 1024,
     height: 640,
-    backgroundColor: '#fcfcfc',
 } as const;
 
 export const defaultCanvasStyles: CanvasStyles = {
@@ -18,16 +17,13 @@ export const defaultCanvasStyles: CanvasStyles = {
     paddingRight: '0px',
     paddingBottom: '0px',
     paddingTop: '0px',
-    backgroundColor: '#fff',
 } as const;
 
 export const defaultEnvironmentProperties = {
     windowWidth: defaultWindowStyles.width,
     windowHeight: defaultWindowStyles.height,
-    windowBackgroundColor: defaultWindowStyles.backgroundColor,
     canvasMargin: {},
     canvasPadding: {},
-    canvasBackgroundColor: defaultCanvasStyles.backgroundColor,
 };
 
 const applyStylesToWindow = (windowStyles: IWindowEnvironmentProps = {}, previousProps: IWindowEnvironmentProps) => {
@@ -71,7 +67,7 @@ const applyStylesToCanvas = (canvas: HTMLDivElement, environmentProps: ICanvasEn
         paddingTop: environmentProps.canvasPadding?.top
             ? `${environmentProps.canvasPadding?.top}px`
             : defaultCanvasStyles.paddingTop,
-        backgroundColor: environmentProps.canvasBackgroundColor || defaultCanvasStyles.backgroundColor,
+        backgroundColor: environmentProps.canvasBackgroundColor || '',
     };
 
     // Canvas gets stretched horizontally/vertically

--- a/packages/board-core/src/types.ts
+++ b/packages/board-core/src/types.ts
@@ -163,7 +163,6 @@ export type BoardSetupStageFunction = (
 
 export type CanvasStyles = Pick<
     CSSStyleDeclaration,
-    | 'backgroundColor'
     | 'height'
     | 'width'
     | 'paddingLeft'


### PR DESCRIPTION
- Fixed not resetting `windowBackgroundColor` if it was removed from `environmentProps`
- Remove occurrence of `backgroundColor` through `previousWindowEnvironmentProps` because it's not in use anymore
- Remove occurrence of `backgroundColor` through `canvasStyle` because it's not in use anymore