### PR TITLE
feat!: use React's new createRoot API

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,9 @@
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-requiring-type-checking"
       ],
+      "rules": {
+        "@typescript-eslint/unbound-method": "off"
+      },
       "excludedFiles": ["packages/*/*.d.ts"]
     }
   ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,3 +18,5 @@ jobs:
       - run: yarn config set network-timeout 300000
       - run: yarn --frozen-lockfile
       - run: yarn test
+      - run: yarn add react@17 react-dom@17 --dev -W
+      - run: yarn test:browser

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/react-dom": "^18.0.5",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
+    "@wixc3/create-disposables": "^2.0.0",
     "chai": "^4.3.6",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/board-core/src/create-renderable-base.ts
+++ b/packages/board-core/src/create-renderable-base.ts
@@ -10,12 +10,13 @@ export type OmitIRenderableMetadataBase<DATA extends IRenderableMetadataBase> = 
 
 export async function baseRender<DATA extends IRenderableMetadataBase>(
     data: DATA,
-    render: (target: HTMLElement) => Promise<void>,
+    render: (target: HTMLElement) => Promise<() => void>,
     canvas: HTMLElement
-): Promise<void> {
+): Promise<() => void> {
     callHooks<IRenderableMetadataBase, 'beforeRender'>(data, 'beforeRender', canvas);
-    await render(canvas);
+    const cleanup = await render(canvas);
     callHooks<IRenderableMetadataBase, 'afterRender'>(data, 'afterRender', canvas);
+    return cleanup;
 }
 
 export function createRenderableBase<DATA extends IRenderableMetadataBase>(

--- a/packages/board-core/src/types.ts
+++ b/packages/board-core/src/types.ts
@@ -124,13 +124,11 @@ export interface IRenderableLifeCycleHooks<PLUGINPARAMS = never> extends HookMap
 export interface IRenderableMetadataBase<HOOKS extends HookMap = HookMap>
     extends IGeneralMetadata<HOOKS & IRenderableLifeCycleHooks> {
     /**
-     * renders the Renderable into an html element
+     * Renders the Renderable into an html element
+     *
+     * @returns a cleanup function
      */
-    render: (targetElement: HTMLElement) => Promise<void>;
-    /**
-     * cleans everything render does
-     */
-    cleanup: (targetElement: HTMLElement) => void;
+    render: (targetElement: HTMLElement) => Promise<() => void>;
     /**
      * sets the stage for the renderer.
      * this function has many side effects ( such as effecting window styles and sizes )

--- a/packages/board-plugins/test/react-context-plugin.spec.ts
+++ b/packages/board-plugins/test/react-context-plugin.spec.ts
@@ -1,24 +1,17 @@
 import { expect } from 'chai';
+import { createDisposables } from '@wixc3/create-disposables';
 import board from './fixtures/context-user.board';
 
 describe('react context plugin', () => {
-    const cleanupAfterTest = new Set<() => unknown>();
-    afterEach(() => {
-        for (const cleanup of cleanupAfterTest) {
-            cleanup();
-        }
-        cleanupAfterTest.clear();
-    });
+    const disposables = createDisposables();
+    afterEach(disposables.dispose);
 
     it('wraps the board with context', async () => {
         const { canvas, cleanup } = board.setupStage();
-        cleanupAfterTest.add(cleanup);
-        await board.render(canvas);
+        disposables.add(cleanup);
+        const cleanupRender = await board.render(canvas);
+        disposables.add(cleanupRender);
 
         expect(canvas.innerText).to.include('context text');
-        cleanup();
-        cleanupAfterTest.delete(cleanup);
-
-        expect(document.getElementById('board-canvas')).to.equal(null);
     });
 });

--- a/packages/react-board/src/create-board.tsx
+++ b/packages/react-board/src/create-board.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { getPluginsWithHooks, baseRender, createRenderableBase } from '@wixc3/board-core';
 import { reactErrorHandledRendering } from './react-error-handled-render';
 import type { IReactBoard, OmitReactBoard } from './types';
@@ -19,13 +18,10 @@ export function createBoard(input: OmitReactBoard<IReactBoard>): IReactBoard {
                             element = el || element;
                         }
                     }
-                    await reactErrorHandledRendering(element, target);
+                    return reactErrorHandledRendering(element, target);
                 },
                 target
             );
-        },
-        cleanup(target) {
-            ReactDOM.unmountComponentAtNode(target);
         },
     });
     return res;

--- a/packages/react-board/src/react-error-handled-render.tsx
+++ b/packages/react-board/src/react-error-handled-render.tsx
@@ -1,28 +1,50 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import ReactDOMClient from 'react-dom/client';
 
-export const reactErrorHandledRendering = (element: JSX.Element, container: HTMLElement) =>
-    new Promise<void>((resolve, reject) => {
-        ReactDOM.render(<ErrorBoundary reportError={reject}>{element}</ErrorBoundary>, container, resolve);
+export const reactErrorHandledRendering = async (element: React.ReactElement, container: HTMLElement) => {
+    const reactRoot = ReactDOMClient.createRoot
+        ? ReactDOMClient.createRoot(container)
+        : createReactLegacyRoot(container);
+    await new Promise<void>((resolve, reject) => {
+        reactRoot.render(
+            <ErrorBoundary onMount={resolve} reportError={reject}>
+                {element}
+            </ErrorBoundary>
+        );
     });
+    return () => reactRoot.unmount();
+};
 
-class ErrorBoundary extends React.Component<
-    React.PropsWithChildren<{ reportError?(error: unknown, errorInfo: React.ErrorInfo): void }>,
-    { hasError: boolean }
-> {
+interface ErrorBoundryProps {
+    onMount?(): void;
+    reportError?(error: unknown, errorInfo: React.ErrorInfo): void;
+}
+
+class ErrorBoundary extends React.Component<React.PropsWithChildren<ErrorBoundryProps>, { hasError: boolean }> {
     public override state = { hasError: false };
-
     static getDerivedStateFromError() {
         return { hasError: true };
     }
     public override componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
         this.props.reportError?.(error, errorInfo);
     }
-
-    public override render() {
-        if (this.state.hasError) {
-            return null;
-        }
-        return this.props.children;
+    public override componentDidMount() {
+        this.props.onMount?.();
     }
+    public override render() {
+        return this.state.hasError ? null : this.props.children;
+    }
+}
+
+// react-dom@<=17 didn't have createRoot, so we polyfill one that uses previous APIs
+function createReactLegacyRoot(container: HTMLElement) {
+    return {
+        render(children: React.ReactElement) {
+            ReactDOM.render(children, container);
+        },
+        unmount() {
+            ReactDOM.unmountComponentAtNode(container);
+        },
+    };
 }

--- a/packages/react-board/test/setup-stage.spec.tsx
+++ b/packages/react-board/test/setup-stage.spec.tsx
@@ -1,20 +1,20 @@
 import { expect } from 'chai';
+import { createDisposables } from '@wixc3/create-disposables';
 import { createBoard } from '@wixc3/react-board';
 import { setupBoardStage } from '@wixc3/board-core';
 
-const CONTAINER_HEIGHT = 50;
+describe('setupBoardStage', () => {
+    const disposables = createDisposables();
+    afterEach(disposables.dispose);
 
-describe('setup stage', () => {
-    const cleanupAfterTest = new Set<() => unknown>();
-    afterEach(() => {
-        for (const cleanup of cleanupAfterTest) {
-            cleanup();
-        }
-        cleanupAfterTest.clear();
-    });
+    const CONTAINER_HEIGHT = 50;
 
     function setupBoard() {
-        const container = createCanvasContainer();
+        const container = document.createElement('div');
+        container.style.display = 'flex';
+        container.style.height = `${CONTAINER_HEIGHT}px`;
+        document.body.appendChild(container);
+        disposables.add(() => document.body.removeChild(container));
 
         const { canvas, cleanup, updateCanvas, updateWindow } = setupBoardStage(
             createBoard({
@@ -24,28 +24,30 @@ describe('setup stage', () => {
             container
         );
 
-        cleanupAfterTest.add(cleanup);
+        disposables.add(cleanup);
 
         return { canvas, container, updateWindow, updateCanvas };
     }
 
     it('renders the canvas into a parent element', () => {
         const { canvas, container } = setupBoard();
+
         expect(canvas.parentElement, 'canvas was not rendered into a provided container').to.eql(container);
     });
 
     it('sets canvas height and canvas width to the provided values if no margin is provided', () => {
         const { updateCanvas, canvas } = setupBoard();
 
-        const canvasSize = { canvasHeight: 690, canvasWidth: 420 };
+        const canvasWidth = 420;
+        const canvasHeight = 690;
 
         updateCanvas({
-            canvasWidth: canvasSize.canvasWidth,
-            canvasHeight: canvasSize.canvasHeight,
+            canvasWidth,
+            canvasHeight,
         });
 
-        expect(canvas?.offsetHeight, 'canvas height was not updated').equal(canvasSize.canvasHeight);
-        expect(canvas?.offsetWidth, 'canvas width was not updated').equal(canvasSize.canvasWidth);
+        expect(canvas.offsetWidth, 'canvas width was not updated').equal(canvasWidth);
+        expect(canvas.offsetHeight, 'canvas height was not updated').equal(canvasHeight);
     });
 
     it('sets canvas height to auto if a "top" and "bottom" margin is provided', () => {
@@ -91,16 +93,9 @@ describe('setup stage', () => {
         const { updateWindow } = setupBoard();
 
         updateWindow({ windowBackgroundColor: '#fff' });
+
         expect(window.getComputedStyle(document.body).backgroundColor, 'window background color was not updated').equal(
             'rgb(255, 255, 255)'
         );
     });
 });
-
-function createCanvasContainer() {
-    const container = document.createElement('div');
-    container.style.display = 'flex';
-    container.style.height = `${CONTAINER_HEIGHT}px`;
-    document.body.appendChild(container);
-    return container;
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,4 +11,10 @@ module.exports = {
             },
         ],
     },
+    resolve: {
+        fallback: {
+            // for react@17 test run
+            'react-dom/client': false
+        }
+    }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,6 +1393,11 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
+"@wixc3/create-disposables@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@wixc3/create-disposables/-/create-disposables-2.0.0.tgz#c3a1121a2d02e38be9bc737d1c4362486fd89871"
+  integrity sha512-WH6hy2/1Cl5N1/uTXlqt9jzyyeoaCmBw+g+X+SOKE7z0Cw+kCM2tMkyeOFSFNsKd7jVdG35i9jIacHbXi9d3cg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
to fully support `react@18`, we need to use the new API: https://reactjs.org/docs/react-dom-client.html#createroot

using it requires two breaking changes:
1. board's render() fn now returns the cleanup callback, rather than it being a separate fn (that expected a container).
2. import to `react-dom/client` requires remapping (`fallback: {'react-dom/client': false}`) when used alongside react 16/17. runtime code polyfills it, but the import still needs to be handled.

made sure we know rendering ended using onMount hook via `ErrorBoundry` instead of a third render() parameter (which doesn't exist in createRoot).

also:
- ensure CI tests react@17 as well
- refactor cleanup code in tests to use createDisposbles and properly remove test container from body.